### PR TITLE
Add jitter to websocket client reconnection backoff

### DIFF
--- a/wsbot/internal/transport/wsclient/client.go
+++ b/wsbot/internal/transport/wsclient/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"math"
+	"math/rand"
 	"net/http"
 	"sync"
 	"time"
@@ -12,6 +13,10 @@ import (
 	"example.com/wsbot/internal/util/config"
 	"nhooyr.io/websocket"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 type OnMessage func(raw []byte)
 
@@ -191,5 +196,6 @@ func backoffTime(cfg config.Config, retries int) time.Duration {
 	if d <= 0 {
 		d = 1 * time.Second
 	}
-	return d
+	jitter := 1 + (rand.Float64()*0.2 - 0.1)
+	return time.Duration(float64(d) * jitter)
 }


### PR DESCRIPTION
## Summary
- introduce +/-10% random jitter in wsclient backoff time
- seed math/rand for jitter calculation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a1cc9e68e4832caa78b513f2434b0a